### PR TITLE
Adds a title to the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         <link rel="canonical" href="https://logary.github.io/">
         <link rel="shortcut icon" href="./img/favicon.ico">
 
-        <title>None</title>
+        <title>Logary - Logging for .NET</title>
 
         <link href="./css/bootstrap-custom.min.css" rel="stylesheet">
         <link href="./css/font-awesome-4.0.3.css" rel="stylesheet">


### PR DESCRIPTION
I was looking over the Logary docs and noticed that the home page doesn't have a title.